### PR TITLE
feat: add villager daytime actions

### DIFF
--- a/common/src/main/kotlin/fr/agrouagrou/common/GameManager.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/GameManager.kt
@@ -5,7 +5,9 @@ import fr.agrouagrou.common.player.PlayerManager
 import fr.agrouagrou.common.turn.GameTurn
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class GameManager(private val rules: GameRules) {
+class GameManager(
+    private val rules: GameRules,
+) {
     var gameState: MutableStateFlow<GameState> = MutableStateFlow(GameState.LOOKING_FOR_PLAYERS)
     val playerManager = PlayerManager(LocalPlayerRegistry(), gameState, rules)
 
@@ -41,6 +43,11 @@ class GameManager(private val rules: GameRules) {
             GameState.NIGHT_FORTUNE_TELLER -> currentTurn().fortuneTellerActions.nextGameState()
             GameState.NIGHT_WEREWOLF -> currentTurn().werewolfActions.nextGameState()
             GameState.NIGHT_WITCH -> currentTurn().witchActions.nextGameState()
+            GameState.DAY_DEBATE -> gameState.value = GameState.DAY_VOTE
+            GameState.DAY_VOTE -> {
+                currentTurn().villagerActions.nextGameState()
+                nextTurn()
+            }
         }
     }
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/GameState.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/GameState.kt
@@ -6,4 +6,6 @@ enum class GameState {
     NIGHT_FORTUNE_TELLER,
     NIGHT_WEREWOLF,
     NIGHT_WITCH,
+    DAY_DEBATE,
+    DAY_VOTE,
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/extensions/GameState.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/extensions/GameState.kt
@@ -10,6 +10,8 @@ fun GameState.toProto() =
         GameState.NIGHT_FORTUNE_TELLER -> GameStateStatus.NIGHT_FORTUNE_TELLER
         GameState.NIGHT_WEREWOLF -> GameStateStatus.NIGHT_WEREWOLF
         GameState.NIGHT_WITCH -> GameStateStatus.NIGHT_WITCH
+        GameState.DAY_DEBATE -> GameStateStatus.DAY_DEBATE
+        GameState.DAY_VOTE -> GameStateStatus.DAY_VOTE
     }
 
 fun GameStateStatus.toGameState() =
@@ -19,5 +21,7 @@ fun GameStateStatus.toGameState() =
         GameStateStatus.NIGHT_FORTUNE_TELLER -> GameState.NIGHT_FORTUNE_TELLER
         GameStateStatus.NIGHT_WEREWOLF -> GameState.NIGHT_WEREWOLF
         GameStateStatus.NIGHT_WITCH -> GameState.NIGHT_WITCH
+        GameStateStatus.DAY_DEBATE -> GameState.DAY_DEBATE
+        GameStateStatus.DAY_VOTE -> GameState.DAY_VOTE
         GameStateStatus.UNRECOGNIZED -> throw IllegalArgumentException("Unrecognized game state")
     }

--- a/common/src/main/kotlin/fr/agrouagrou/common/player/LocalPlayerRegistry.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/player/LocalPlayerRegistry.kt
@@ -27,9 +27,7 @@ class LocalPlayerRegistry : PlayerRegistry {
         }
     }
 
-    override fun getPlayerStatus(id: UUID): PlayerStatus {
-        return getPlayer(id).status
-    }
+    override fun getPlayerStatus(id: UUID): PlayerStatus = getPlayer(id).status
 
     override fun setPlayerStatus(
         id: UUID,
@@ -38,7 +36,13 @@ class LocalPlayerRegistry : PlayerRegistry {
         getPlayer(id).status = status
     }
 
-    private fun getPlayer(id: UUID): Player {
-        return _players[id] ?: throw IllegalArgumentException("Player $id not found")
+    override fun finishOffDyingPlayers() {
+        _players.values
+            .filter { it.status == PlayerStatus.DYING }
+            .forEach { it.status = PlayerStatus.DEAD }
     }
+
+    override fun getAlivePlayerCount(): Int = _players.values.count { it.status == PlayerStatus.ALIVE }
+
+    private fun getPlayer(id: UUID): Player = _players[id] ?: throw IllegalArgumentException("Player $id not found")
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/player/PlayerRegistry.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/player/PlayerRegistry.kt
@@ -18,9 +18,17 @@ interface PlayerRegistry {
         status: PlayerStatus,
     )
 
-    sealed class Notification {
-        data class PlayerRegistered(val player: Player) : Notification()
+    fun finishOffDyingPlayers()
 
-        data class PlayerUnregistered(val id: UUID) : Notification()
+    fun getAlivePlayerCount(): Int
+
+    sealed class Notification {
+        data class PlayerRegistered(
+            val player: Player,
+        ) : Notification()
+
+        data class PlayerUnregistered(
+            val id: UUID,
+        ) : Notification()
     }
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/player/Role.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/player/Role.kt
@@ -5,7 +5,10 @@ sealed class Role {
 
     data object Werewolf : Role()
 
-    data class Witch(var deathPotion: Int = 1, var lifePotion: Int = 1) : Role() {
+    data class Witch(
+        var deathPotion: Int = 1,
+        var lifePotion: Int = 1,
+    ) : Role() {
         fun useDeathPotion() {
             if (deathPotion <= 0) {
                 throw IllegalStateException("Witch has no more death potion")

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/DebugService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/DebugService.kt
@@ -9,7 +9,9 @@ import fr.agrouagrou.proto.SetGameStateReply
 import fr.agrouagrou.proto.SetGameStateRequest
 import fr.agrouagrou.proto.setGameStateReply
 
-class DebugService(private val gameManager: GameManager) : DebugGrpcKt.DebugCoroutineImplBase() {
+class DebugService(
+    private val gameManager: GameManager,
+) : DebugGrpcKt.DebugCoroutineImplBase() {
     override suspend fun startGame(request: Empty): Empty {
         gameManager.startGame()
         return Empty.getDefaultInstance()

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/GameStateService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/GameStateService.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 
-class GameStateService(private val gameManager: GameManager) : GameStateGrpcKt.GameStateCoroutineImplBase() {
+class GameStateService(
+    private val gameManager: GameManager,
+) : GameStateGrpcKt.GameStateCoroutineImplBase() {
     override suspend fun getGameState(request: Empty) =
         getGameStateReply {
             status = gameManager.gameState.value.toProto()

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/PlayerService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/PlayerService.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
 import java.util.*
 
-class PlayerService(private val playerManager: PlayerManager) : PlayerGrpcKt.PlayerCoroutineImplBase() {
+class PlayerService(
+    private val playerManager: PlayerManager,
+) : PlayerGrpcKt.PlayerCoroutineImplBase() {
     override suspend fun register(request: PlayerRegisterRequest): PlayerReply {
         val player = playerManager.register(request.username)
         println("Registering new player: $player")
@@ -32,7 +34,10 @@ class PlayerService(private val playerManager: PlayerManager) : PlayerGrpcKt.Pla
         return Empty.getDefaultInstance()
     }
 
-    override fun getPlayers(request: Empty): Flow<PlayerReply> = playerManager.players.values.map { it.toProto() }.asFlow()
+    override fun getPlayers(request: Empty): Flow<PlayerReply> =
+        playerManager.players.values
+            .map { it.toProto() }
+            .asFlow()
 
     override fun streamPlayerNotifications(request: Empty): Flow<PlayerNotification> =
         flow {

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/roles/FortuneTellerService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/roles/FortuneTellerService.kt
@@ -7,10 +7,16 @@ import fr.agrouagrou.proto.RevealRoleReply
 import fr.agrouagrou.proto.RevealRoleRequest
 import fr.agrouagrou.proto.revealRoleReply
 
-class FortuneTellerService(private val gameManager: GameManager) : FortuneTellerActionsGrpcKt.FortuneTellerActionsCoroutineImplBase() {
-    override suspend fun revealRole(request: RevealRoleRequest): RevealRoleReply {
-        return revealRoleReply {
-            role = gameManager.currentTurn().fortuneTellerActions.revealRole(request.playerId, request.targetId).toProto()
+class FortuneTellerService(
+    private val gameManager: GameManager,
+) : FortuneTellerActionsGrpcKt.FortuneTellerActionsCoroutineImplBase() {
+    override suspend fun revealRole(request: RevealRoleRequest): RevealRoleReply =
+        revealRoleReply {
+            role =
+                gameManager
+                    .currentTurn()
+                    .fortuneTellerActions
+                    .revealRole(request.playerId, request.targetId)
+                    .toProto()
         }
-    }
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/roles/VillagerService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/roles/VillagerService.kt
@@ -1,0 +1,15 @@
+package fr.agrouagrou.common.service.roles
+
+import com.google.protobuf.Empty
+import fr.agrouagrou.common.GameManager
+import fr.agrouagrou.proto.VillagerActionsGrpcKt
+import fr.agrouagrou.proto.VoteVillagerVictimRequest
+
+class VillagerService(
+    private val gameManager: GameManager,
+) : VillagerActionsGrpcKt.VillagerActionsCoroutineImplBase() {
+    override suspend fun voteVictim(request: VoteVillagerVictimRequest): Empty {
+        gameManager.currentTurn().villagerActions.voteVictim(request.playerId, request.targetId)
+        return Empty.getDefaultInstance()
+    }
+}

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/roles/WerewolfService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/roles/WerewolfService.kt
@@ -2,11 +2,13 @@ package fr.agrouagrou.common.service.roles
 
 import com.google.protobuf.Empty
 import fr.agrouagrou.common.GameManager
-import fr.agrouagrou.proto.VoteVictimRequest
+import fr.agrouagrou.proto.VoteWerewolfVictimRequest
 import fr.agrouagrou.proto.WerewolfActionsGrpcKt
 
-class WerewolfService(private val gameManager: GameManager) : WerewolfActionsGrpcKt.WerewolfActionsCoroutineImplBase() {
-    override suspend fun voteVictim(request: VoteVictimRequest): Empty {
+class WerewolfService(
+    private val gameManager: GameManager,
+) : WerewolfActionsGrpcKt.WerewolfActionsCoroutineImplBase() {
+    override suspend fun voteVictim(request: VoteWerewolfVictimRequest): Empty {
         gameManager.currentTurn().werewolfActions.voteVictim(request.playerId, request.targetId)
         return Empty.getDefaultInstance()
     }

--- a/common/src/main/kotlin/fr/agrouagrou/common/service/roles/WitchService.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/service/roles/WitchService.kt
@@ -6,7 +6,9 @@ import fr.agrouagrou.proto.KillPlayerRequest
 import fr.agrouagrou.proto.RevivePlayerRequest
 import fr.agrouagrou.proto.WitchActionsGrpcKt
 
-class WitchService(private val gameManager: GameManager) : WitchActionsGrpcKt.WitchActionsCoroutineImplBase() {
+class WitchService(
+    private val gameManager: GameManager,
+) : WitchActionsGrpcKt.WitchActionsCoroutineImplBase() {
     override suspend fun killPlayer(request: KillPlayerRequest): Empty {
         gameManager.currentTurn().witchActions.killPlayer(request.playerId, request.targetId)
         return Empty.getDefaultInstance()

--- a/common/src/main/kotlin/fr/agrouagrou/common/turn/GameTurn.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/turn/GameTurn.kt
@@ -5,8 +5,14 @@ import fr.agrouagrou.common.GameState
 import fr.agrouagrou.common.player.PlayerManager
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class GameTurn(val turnNumber: Int, gameState: MutableStateFlow<GameState>, playerManager: PlayerManager, rules: GameRules) {
+class GameTurn(
+    val turnNumber: Int,
+    gameState: MutableStateFlow<GameState>,
+    playerManager: PlayerManager,
+    rules: GameRules,
+) {
     val fortuneTellerActions = FortuneTellerActions(gameState, playerManager)
     val werewolfActions = WerewolfActions(gameState, playerManager, rules.werewolfCount)
     val witchActions = WitchActions(gameState, playerManager)
+    val villagerActions = VillagerActions(gameState, playerManager)
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/turn/RoleActions.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/turn/RoleActions.kt
@@ -2,20 +2,21 @@ package fr.agrouagrou.common.turn
 
 import fr.agrouagrou.common.GameState
 import fr.agrouagrou.common.player.Player
-import fr.agrouagrou.common.player.Role
-import kotlin.reflect.KClass
+import fr.agrouagrou.common.player.PlayerStatus
 
-abstract class RoleActions<T : Role>(private val role: KClass<T>, private val validState: GameState) {
-    fun validateAction(
+abstract class RoleActions(
+    private val validState: GameState,
+) {
+    open fun validateAction(
         player: Player,
         gameState: GameState,
     ) {
-        if (player.role::class != role) {
-            throw IllegalArgumentException("Player does not have the required role")
-        }
-
         if (gameState != validState) {
             throw IllegalArgumentException("This action is not allowed at this time")
+        }
+
+        if (player.status == PlayerStatus.DEAD) {
+            throw IllegalArgumentException("Dead players cannot perform actions")
         }
     }
 

--- a/common/src/main/kotlin/fr/agrouagrou/common/turn/SpecificRoleActions.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/turn/SpecificRoleActions.kt
@@ -1,0 +1,22 @@
+package fr.agrouagrou.common.turn
+
+import fr.agrouagrou.common.GameState
+import fr.agrouagrou.common.player.Player
+import fr.agrouagrou.common.player.Role
+import kotlin.reflect.KClass
+
+abstract class SpecificRoleActions<T : Role>(
+    private val role: KClass<T>,
+    validState: GameState,
+) : RoleActions(validState) {
+    override fun validateAction(
+        player: Player,
+        gameState: GameState,
+    ) {
+        super.validateAction(player, gameState)
+
+        if (player.role::class != role) {
+            throw IllegalArgumentException("Player does not have the required role")
+        }
+    }
+}

--- a/common/src/main/kotlin/fr/agrouagrou/common/turn/WerewolfActions.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/turn/WerewolfActions.kt
@@ -11,7 +11,7 @@ class WerewolfActions(
     private val gameState: MutableStateFlow<GameState>,
     private val playerManager: PlayerManager,
     private val werewolfCount: Int,
-) : RoleActions<Role.Werewolf>(Role.Werewolf::class, GameState.NIGHT_WEREWOLF) {
+) : SpecificRoleActions<Role.Werewolf>(Role.Werewolf::class, GameState.NIGHT_WEREWOLF) {
     private val votes = mutableMapOf<UUID, UUID>()
 
     fun voteVictim(
@@ -37,11 +37,15 @@ class WerewolfActions(
         }
 
         val mostVotedPlayer =
-            votes.values.groupingBy { it }.eachCount().maxByOrNull { it.value }?.key ?: throw IllegalStateException(
+            votes.values
+                .groupingBy { it }
+                .eachCount()
+                .maxByOrNull { it.value }
+                ?.key ?: throw IllegalStateException(
                 "No votes",
             )
-        playerManager.setPlayerStatus(mostVotedPlayer, PlayerStatus.DYING)
 
+        playerManager.setPlayerStatus(mostVotedPlayer, PlayerStatus.DYING)
         gameState.value = GameState.NIGHT_WITCH
     }
 }

--- a/common/src/main/kotlin/fr/agrouagrou/common/turn/WitchActions.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/turn/WitchActions.kt
@@ -11,7 +11,7 @@ import java.util.*
 class WitchActions(
     private val gameState: MutableStateFlow<GameState>,
     private val playerManager: PlayerManager,
-) : RoleActions<Role.Witch>(Role.Witch::class, GameState.NIGHT_WITCH) {
+) : SpecificRoleActions<Role.Witch>(Role.Witch::class, GameState.NIGHT_WITCH) {
     private var hasUsedPotion = false
 
     fun killPlayer(
@@ -64,6 +64,7 @@ class WitchActions(
     }
 
     override fun nextGameState() {
-        TODO("Not yet implemented")
+        playerManager.finishOffDyingPlayers()
+        gameState.value = GameState.DAY_DEBATE
     }
 }

--- a/dedicated_server/src/main/kotlin/fr/agrouagrou/DedicatedServer.kt
+++ b/dedicated_server/src/main/kotlin/fr/agrouagrou/DedicatedServer.kt
@@ -6,13 +6,17 @@ import fr.agrouagrou.common.service.DebugService
 import fr.agrouagrou.common.service.GameStateService
 import fr.agrouagrou.common.service.PlayerService
 import fr.agrouagrou.common.service.roles.FortuneTellerService
+import fr.agrouagrou.common.service.roles.VillagerService
 import fr.agrouagrou.common.service.roles.WerewolfService
 import fr.agrouagrou.common.service.roles.WitchService
 import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
 
-class DedicatedServer(gameRules: GameRules, private val port: Int) {
+class DedicatedServer(
+    gameRules: GameRules,
+    private val port: Int,
+) {
     private val gameManager = GameManager(gameRules)
 
     private val server: Server =
@@ -24,6 +28,7 @@ class DedicatedServer(gameRules: GameRules, private val port: Int) {
             .addService(FortuneTellerService(gameManager))
             .addService(WerewolfService(gameManager))
             .addService(WitchService(gameManager))
+            .addService(VillagerService(gameManager))
             .addService(ProtoReflectionService.newInstance())
             .intercept(GrpcExceptionInterceptor())
             .build()

--- a/dedicated_server/src/main/kotlin/fr/agrouagrou/GrpcExceptionInterceptor.kt
+++ b/dedicated_server/src/main/kotlin/fr/agrouagrou/GrpcExceptionInterceptor.kt
@@ -41,7 +41,5 @@ class GrpcExceptionInterceptor : ServerInterceptor {
         call: ServerCall<ReqT, RespT>,
         headers: Metadata,
         next: ServerCallHandler<ReqT, RespT>,
-    ): ServerCall.Listener<ReqT> {
-        return next.startCall(ExceptionTranslatingServerCall(call), headers)
-    }
+    ): ServerCall.Listener<ReqT> = next.startCall(ExceptionTranslatingServerCall(call), headers)
 }

--- a/protos/src/main/proto/game_state.proto
+++ b/protos/src/main/proto/game_state.proto
@@ -12,6 +12,8 @@ enum GameStateStatus {
   NIGHT_FORTUNE_TELLER = 2;
   NIGHT_WEREWOLF = 3;
   NIGHT_WITCH = 4;
+  DAY_DEBATE = 5;
+  DAY_VOTE = 6;
 }
 
 // GetGameState

--- a/protos/src/main/proto/roles/villager.proto
+++ b/protos/src/main/proto/roles/villager.proto
@@ -8,11 +8,11 @@ option java_package = "fr.agrouagrou.proto";
 package proto;
 
 // VoteVictim
-message VoteWerewolfVictimRequest {
+message VoteVillagerVictimRequest {
   string playerId = 1;
   string targetId = 2;
 }
 
-service WerewolfActions {
-  rpc VoteVictim (VoteWerewolfVictimRequest) returns (google.protobuf.Empty) {}
+service VillagerActions {
+  rpc VoteVictim (VoteVillagerVictimRequest) returns (google.protobuf.Empty) {}
 }


### PR DESCRIPTION
This adds the game states for day time, one in which the players have time to think about their victim (`GameState.DAY_DEBATE`), and another one in which the players can vote for the victim (`GameState.DAY_VOTE`).

After the villagers have all voted, a new turn is started with the villagers victim being dead and another night starting.

## Other changes

Role actions now validate that the player attempting to use the action is not dead.