### PR TITLE
feat: add GameMaster view model

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="true"
@@ -27,5 +28,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/fr/agrouagrou/mobileapp/MainActivity.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.Text
 import androidx.lifecycle.ViewModel
 import androidx.navigation.compose.rememberNavController
 import fr.agrouagrou.mobileapp.ui.theme.AppTheme

--- a/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
@@ -3,20 +3,22 @@ package fr.agrouagrou.mobileapp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.navigation.compose.NavHost
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import fr.agrouagrou.mobileapp.ui.common.GameViewModel
 import fr.agrouagrou.mobileapp.ui.createjoingame.CreateGameRoute
 import fr.agrouagrou.mobileapp.ui.createjoingame.HomeRoute
 import fr.agrouagrou.mobileapp.ui.createjoingame.JoinGameRoute
+import fr.agrouagrou.mobileapp.ui.gamephases.GamePhaseGameMasterRoute
 
 object Destinations {
     const val HOME = "home"
     const val CREATE_GAME = "create-game"
     const val JOIN_GAME = "join-game"
     const val GAME_PHASE = "game-phase"
+    const val GAME_PHASE_GAMEMASTER = "game-phase-gamemaster"
 }
 
 @Composable
@@ -41,11 +43,18 @@ fun AgrouAgrouNavHost(
         }
 
         composable(Destinations.CREATE_GAME) {
-            CreateGameRoute(gameViewModel)
+            CreateGameRoute(
+                gameViewModel,
+                onStartGame = { navController.navigate(Destinations.GAME_PHASE_GAMEMASTER) }
+            )
         }
 
         composable(Destinations.JOIN_GAME) {
             JoinGameRoute()
+        }
+
+        composable(Destinations.GAME_PHASE_GAMEMASTER) {
+            GamePhaseGameMasterRoute()
         }
 
         composable(Destinations.GAME_PHASE) {

--- a/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
@@ -1,11 +1,13 @@
 package fr.agrouagrou.mobileapp
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.compose.NavHost
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import fr.agrouagrou.mobileapp.ui.common.GameViewModel
 import fr.agrouagrou.mobileapp.ui.createjoingame.CreateGameRoute
 import fr.agrouagrou.mobileapp.ui.createjoingame.HomeRoute
 import fr.agrouagrou.mobileapp.ui.createjoingame.JoinGameRoute
@@ -14,19 +16,26 @@ object Destinations {
     const val HOME = "home"
     const val CREATE_GAME = "create-game"
     const val JOIN_GAME = "join-game"
+    const val GAME_PHASE = "game-phase"
 }
 
 @Composable
 fun AgrouAgrouNavHost(
     navController: NavHostController = rememberNavController(),
 ) {
+    val gameViewModel = GameViewModel()
+    val gameUiState by gameViewModel.gameManager.collectAsState()
+
     NavHost(
         navController = navController,
         startDestination = Destinations.HOME
     ) {
         composable(Destinations.HOME) {
             HomeRoute(
-                onCreateGame = { navController.navigate(Destinations.CREATE_GAME) },
+                onCreateGame = {
+                    gameViewModel.createGame()
+                    navController.navigate(Destinations.CREATE_GAME);
+                },
                 onJoinGame = { navController.navigate(Destinations.JOIN_GAME) }
             )
         }
@@ -37,6 +46,10 @@ fun AgrouAgrouNavHost(
 
         composable(Destinations.JOIN_GAME) {
             JoinGameRoute()
+        }
+
+        composable(Destinations.GAME_PHASE) {
+            // GamePhaseRoute()
         }
     }
 }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
@@ -41,7 +41,7 @@ fun AgrouAgrouNavHost(
         }
 
         composable(Destinations.CREATE_GAME) {
-            CreateGameRoute()
+            CreateGameRoute(gameViewModel)
         }
 
         composable(Destinations.JOIN_GAME) {

--- a/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/Navigation.kt
@@ -1,5 +1,6 @@
 package fr.agrouagrou.mobileapp
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,7 +46,14 @@ fun AgrouAgrouNavHost(
         composable(Destinations.CREATE_GAME) {
             CreateGameRoute(
                 gameViewModel,
-                onStartGame = { navController.navigate(Destinations.GAME_PHASE_GAMEMASTER) }
+                onStartGame = {
+                    try {
+                        gameViewModel.gameManager.value.startGame()
+                        navController.navigate(Destinations.GAME_PHASE_GAMEMASTER)
+                    } catch (e: IllegalStateException) {
+                        Log.e("Navigation", "Could not start game: $e")
+                    }
+                }
             )
         }
 
@@ -54,7 +62,7 @@ fun AgrouAgrouNavHost(
         }
 
         composable(Destinations.GAME_PHASE_GAMEMASTER) {
-            GamePhaseGameMasterRoute()
+            GamePhaseGameMasterRoute(gameViewModel)
         }
 
         composable(Destinations.GAME_PHASE) {

--- a/app/src/main/java/fr/agrouagrou/mobileapp/Utils.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/Utils.kt
@@ -2,6 +2,9 @@ package fr.agrouagrou.mobileapp
 
 import fr.agrouagrou.common.player.Role
 import fr.agrouagrou.grpc_server.R
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.util.Collections
 
 fun roleToImage(role: Role?): Int = when (role) {
     Role.Villager -> R.drawable.simple_villager
@@ -9,4 +12,48 @@ fun roleToImage(role: Role?): Int = when (role) {
     is Role.Witch -> R.drawable.witch
     Role.FortuneTeller -> R.drawable.fortune_teller
     null -> R.drawable.card_back
+}
+
+fun getPrivateIpAddress(): String? {
+    return try {
+        val interfaces = Collections.list(NetworkInterface.getNetworkInterfaces())
+        for (networkInterface in interfaces) {
+            val addresses = Collections.list(networkInterface.inetAddresses)
+            for (address in addresses) {
+                if (!address.isLoopbackAddress && address is Inet4Address) {
+                    return address.hostAddress
+                }
+            }
+        }
+        null
+    } catch (ex: Exception) {
+        ex.printStackTrace()
+        null
+    }
+}
+
+object IpPortEncDec {
+    fun encodeIpPort(ip: String, port: Int): String {
+        val ipParts = ip.split(".").map { it.toInt().toString(16).padStart(2, '0') }
+        val ipHex = ipParts.joinToString("")
+        val portHex = port.toString(16).padStart(4, '0')
+        return "$ipHex-$portHex"
+    }
+
+    fun decodeIpPort(encodedString: String): Pair<String, Int>? {
+        val parts = encodedString.split("-")
+        if (parts.size != 2) return null
+        val ipHex = parts[0]
+        val portHex = parts[1]
+
+        val ip = listOf(
+            ipHex.substring(0, 2).toInt(16),
+            ipHex.substring(2, 4).toInt(16),
+            ipHex.substring(4, 6).toInt(16),
+            ipHex.substring(6, 8).toInt(16)
+        ).joinToString(".")
+
+        val port = portHex.toInt(16)
+        return Pair(ip, port)
+    }
 }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
@@ -49,6 +49,7 @@ class GameViewModel : ViewModel() {
                     Log.d("GameViewModel", "Player registered: ${notification.player}")
                     cb(gameManager.value.playerManager.players.values.toList())
                 }
+
                 is Notification.PlayerUnregistered -> {
                     Log.d("GameViewModel", "Player unregistered: ${notification.id}")
                     cb(gameManager.value.playerManager.players.values.toList())

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
@@ -46,12 +46,10 @@ class GameViewModel : ViewModel() {
         gameManager.value.playerManager.notifications.collect { notification ->
             when (notification) {
                 is Notification.PlayerRegistered -> {
-                    Log.d("GameViewModel", "Player registered: ${notification.player}")
                     cb(gameManager.value.playerManager.players.values.toList())
                 }
 
                 is Notification.PlayerUnregistered -> {
-                    Log.d("GameViewModel", "Player unregistered: ${notification.id}")
                     cb(gameManager.value.playerManager.players.values.toList())
                 }
             }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/GameViewModel.kt
@@ -1,0 +1,48 @@
+package fr.agrouagrou.mobileapp.ui.common
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import fr.agrouagrou.common.GameManager
+import fr.agrouagrou.common.GameRules
+import fr.agrouagrou.common.service.DebugService
+import fr.agrouagrou.common.service.GameStateService
+import fr.agrouagrou.common.service.PlayerService
+import fr.agrouagrou.common.service.roles.FortuneTellerService
+import fr.agrouagrou.common.service.roles.WerewolfService
+import fr.agrouagrou.common.service.roles.WitchService
+import io.grpc.Grpc
+import io.grpc.InsecureServerCredentials
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class GameViewModel : ViewModel() {
+    private val _gameManager = MutableStateFlow(GameManager(GameRules(3, 1)));
+    val gameManager: StateFlow<GameManager> = _gameManager.asStateFlow()
+
+    private val server = Grpc.newServerBuilderForPort(50051, InsecureServerCredentials.create())
+        .addService(GameStateService(_gameManager.value))
+        .addService(PlayerService(_gameManager.value.playerManager))
+        .addService(DebugService(_gameManager.value))
+        .addService(FortuneTellerService(_gameManager.value))
+        .addService(WerewolfService(_gameManager.value))
+        .addService(WitchService(_gameManager.value))
+        .build()
+
+    fun createGame() {
+        server.start()
+        Log.d("GameViewModel", "Server started, listening on 50051")
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                Log.d("GameViewModel", "Shutting down the server")
+                server.shutdown()
+            }
+        )
+    }
+
+    fun joinGame() {
+        
+    }
+}

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/extensions/GameState.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/common/extensions/GameState.kt
@@ -1,0 +1,15 @@
+package fr.agrouagrou.mobileapp.ui.common.extensions
+
+import fr.agrouagrou.common.GameState
+import fr.agrouagrou.grpc_server.R
+
+fun GameState.toLabel() =
+    when (this) {
+        GameState.LOOKING_FOR_PLAYERS -> R.string.gamestate_looking_for_players
+        GameState.NIGHT_START -> R.string.gamestate_night_start
+        GameState.NIGHT_FORTUNE_TELLER -> R.string.gamestate_night_fortune_teller
+        GameState.NIGHT_WEREWOLF -> R.string.gamestate_night_werewolf
+        GameState.NIGHT_WITCH -> R.string.gamestate_night_witch
+        GameState.DAY_DEBATE -> R.string.gamestate_day_debate
+        GameState.DAY_VOTE -> R.string.gamestate_day_vote
+    }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/GameIDInfo.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/GameIDInfo.kt
@@ -3,15 +3,16 @@ package fr.agrouagrou.mobileapp.ui.components
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.startActivity
 import fr.agrouagrou.grpc_server.R
 
@@ -23,9 +24,7 @@ fun GameIDInfo(gameID: String, context: Context, modifier: Modifier = Modifier) 
     }
     val shareIntent = Intent.createChooser(sendIntent, null)
 
-    Column(
-        modifier = modifier,
-    ) {
+    Column(modifier) {
         Text(
             text = stringResource(R.string.waiting_for_other_players),
             color = MaterialTheme.colorScheme.primary
@@ -34,9 +33,9 @@ fun GameIDInfo(gameID: String, context: Context, modifier: Modifier = Modifier) 
             text = stringResource(R.string.your_game_id_is, gameID),
             color = MaterialTheme.colorScheme.primary
         )
-        Button(onClick = {
-            startActivity(context, shareIntent, null)
-        }) {
+        Button(
+            modifier = Modifier.padding(top = 6.dp),
+            onClick = { startActivity(context, shareIntent, null) }) {
             Text(text = stringResource(R.string.copy_game_id))
         }
     }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/JoinGameForm.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/JoinGameForm.kt
@@ -53,7 +53,7 @@ fun JoinGameForm(
             value = gameCode,
             onValueChange = onGameCodeChange,
             label = { Text(text = stringResource(id = R.string.joingame_form_game_code)) },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
         )
         Button(onClick = { onJoinGame(username, gameCode) }) {
             Row(

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/PlayerList.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/PlayerList.kt
@@ -5,11 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.twotone.KeyboardArrowRight
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.twotone.KeyboardArrowRight
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -26,40 +22,35 @@ import fr.agrouagrou.common.player.Role
 import fr.agrouagrou.mobileapp.roleToImage
 
 @Composable
-fun PlayerList(players: List<Player>, onClick: ((Player) -> Unit)? = null ) {
+fun PlayerList(players: List<Player>, onClick: ((Player) -> Unit)? = null) {
     Column {
         players.forEach { player ->
             ListItem(
                 headlineContent = {
                     Text(text = player.username)
                 },
-                supportingContent = if (player.role != null) {
-                    {
-                        Text(text = player.role.toString())
-                    }
-                } else {
-                    null
+                supportingContent = {
+                    Text(text = player.role.toString())
                 },
                 leadingContent = {
                     Image(
                         painter = painterResource(id = roleToImage(player.role)),
                         contentDescription = player.role.toString(),
-                        Modifier
-                            .size(56.dp, 56.dp)
+                        modifier = Modifier.size(56.dp, 56.dp)
                     )
                 },
-                trailingContent = if (onClick != null) {
-                    {
+                trailingContent = {
+                    if (onClick != null) {
                         Icon(
                             imageVector = Icons.AutoMirrored.TwoTone.KeyboardArrowRight,
                             contentDescription = "Edit",
-                            Modifier
+                            modifier = Modifier
                                 .size(24.dp)
                                 .clickable { onClick(player) }
                         )
+                    } else {
+                        null
                     }
-                } else {
-                    null
                 }
             )
             HorizontalDivider()

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/PlayerView.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/components/PlayerView.kt
@@ -17,6 +17,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import fr.agrouagrou.grpc_server.R
+import fr.agrouagrou.mobileapp.ui.gamephases.Card
+import fr.agrouagrou.mobileapp.ui.gamephases.CardPreviewProvider
+import fr.agrouagrou.mobileapp.ui.gamephases.CardView
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
@@ -1,8 +1,15 @@
 package fr.agrouagrou.mobileapp.ui.createjoingame
 
+import android.content.Context
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -28,49 +36,61 @@ import kotlinx.coroutines.withContext
 @Composable
 fun CreateGameRoute(
     gameViewModel: GameViewModel,
+    onStartGame: (() -> Unit)? = null,
 ) {
-    val context = LocalContext.current
     var ipAddress: String? by remember { mutableStateOf(null) }
     LaunchedEffect(Unit) {
         ipAddress = withContext(Dispatchers.IO) { getPrivateIpAddress() }
     }
-    val port = 50051
-    val gameId = if (ipAddress != null) IpPortEncDec.encodeIpPort(ipAddress!!, port) else null
+    val gameId = if (ipAddress != null) IpPortEncDec.encodeIpPort(ipAddress!!, 50051) else null
 
     val gameManager by gameViewModel.gameManager.collectAsState()
     var players by remember { mutableStateOf(gameManager.playerManager.players.values.toList()) }
+    var canStartGame by remember { mutableStateOf(gameManager.canStartGame()) }
     LaunchedEffect(Unit) {
-        gameViewModel.watchForPlayerUpdates { players = it }
-    }
-
-    Column {
-        Column(
-            Modifier
-                .fillMaxWidth()
-                .padding(top = 42.dp, start = 16.dp, end = 16.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.waiting_for_players),
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(bottom = 16.dp)
-            )
-            if (gameId != null) GameIDInfo(
-                gameId,
-                context,
-                modifier = Modifier.padding(bottom = 16.dp)
-            ) else null
+        gameViewModel.watchForPlayerUpdates {
+            players = it
+            canStartGame = gameManager.canStartGame()
         }
-        PlayerList(
-            players = players,
-        )
+    }
+
+    Column(
+        Modifier
+            .padding(top = 48.dp, bottom = 42.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Header(gameId, LocalContext.current)
+        PlayerList(players)
+        if (canStartGame) StartGameButton(onStartGame)
     }
 }
 
-/**
-@Preview
 @Composable
-fun CreateGameRoutePreview() {
-    CreateGameRoute(gameUiState)
+fun Header(gameId: String?, context: Context) {
+    Column(Modifier.padding(start = 16.dp, bottom = 16.dp)) {
+        Text(
+            text = stringResource(R.string.waiting_for_players),
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+        gameId?.let {
+            GameIDInfo(it, context)
+        }
+    }
 }
-*/
+
+@Composable
+fun StartGameButton(onStartGame: (() -> Unit)?) {
+    Column(Modifier.padding(start = 16.dp, top = 16.dp)) {
+        Button(onClick = { onStartGame?.let { it() } }) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
+                    contentDescription = null,
+                )
+                Text(text = stringResource(id = R.string.start_game))
+            }
+        }
+    }
+}

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
@@ -1,27 +1,45 @@
 package fr.agrouagrou.mobileapp.ui.createjoingame
 
+import android.content.Context
+import android.net.wifi.WifiManager
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import fr.agrouagrou.common.GameManager
 import fr.agrouagrou.common.player.Player
 import fr.agrouagrou.common.player.PlayerStatus
 import fr.agrouagrou.grpc_server.R
+import fr.agrouagrou.mobileapp.IpPortEncDec
+import fr.agrouagrou.mobileapp.getPrivateIpAddress
 import fr.agrouagrou.mobileapp.ui.components.GameIDInfo
 import fr.agrouagrou.mobileapp.ui.components.PlayerList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.UUID
 
 @Composable
 fun CreateGameRoute() {
-    val gameID = "ABCD"
     val context = LocalContext.current
+    var ipAddress: String? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(Unit) {
+        ipAddress = withContext(Dispatchers.IO) { getPrivateIpAddress() }
+    }
+
+    val port = 50051
+    val gameId = if (ipAddress != null) IpPortEncDec.encodeIpPort(ipAddress!!, port) else null
 
     Column {
         Column(
@@ -35,7 +53,7 @@ fun CreateGameRoute() {
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
-            GameIDInfo(gameID, context, modifier = Modifier.padding(bottom = 16.dp))
+            if (gameId != null) GameIDInfo(gameId, context, modifier = Modifier.padding(bottom = 16.dp)) else null
         }
         PlayerList(
             players = listOf(
@@ -47,8 +65,10 @@ fun CreateGameRoute() {
     }
 }
 
+/**
 @Preview
 @Composable
 fun CreateGameRoutePreview() {
-    CreateGameRoute()
+    CreateGameRoute(gameUiState)
 }
+*/

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/createjoingame/CreateGameRoute.kt
@@ -1,7 +1,5 @@
 package fr.agrouagrou.mobileapp.ui.createjoingame
 
-import android.content.Context
-import android.net.wifi.WifiManager
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -9,6 +7,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -17,29 +16,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import fr.agrouagrou.common.GameManager
-import fr.agrouagrou.common.player.Player
-import fr.agrouagrou.common.player.PlayerStatus
 import fr.agrouagrou.grpc_server.R
 import fr.agrouagrou.mobileapp.IpPortEncDec
 import fr.agrouagrou.mobileapp.getPrivateIpAddress
+import fr.agrouagrou.mobileapp.ui.common.GameViewModel
 import fr.agrouagrou.mobileapp.ui.components.GameIDInfo
 import fr.agrouagrou.mobileapp.ui.components.PlayerList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.UUID
 
 @Composable
-fun CreateGameRoute() {
+fun CreateGameRoute(
+    gameViewModel: GameViewModel,
+) {
     val context = LocalContext.current
     var ipAddress: String? by remember { mutableStateOf(null) }
-
     LaunchedEffect(Unit) {
         ipAddress = withContext(Dispatchers.IO) { getPrivateIpAddress() }
     }
-
     val port = 50051
     val gameId = if (ipAddress != null) IpPortEncDec.encodeIpPort(ipAddress!!, port) else null
+
+    val gameManager by gameViewModel.gameManager.collectAsState()
+    var players by remember { mutableStateOf(gameManager.playerManager.players.values.toList()) }
+    LaunchedEffect(Unit) {
+        gameViewModel.watchForPlayerUpdates { players = it }
+    }
 
     Column {
         Column(
@@ -53,14 +55,14 @@ fun CreateGameRoute() {
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
-            if (gameId != null) GameIDInfo(gameId, context, modifier = Modifier.padding(bottom = 16.dp)) else null
+            if (gameId != null) GameIDInfo(
+                gameId,
+                context,
+                modifier = Modifier.padding(bottom = 16.dp)
+            ) else null
         }
         PlayerList(
-            players = listOf(
-                Player("Player 1", UUID.randomUUID(), PlayerStatus.ALIVE),
-                Player("Player 2", UUID.randomUUID(), PlayerStatus.ALIVE),
-                Player("Player 3", UUID.randomUUID(), PlayerStatus.ALIVE),
-            )
+            players = players,
         )
     }
 }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/CardView.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/CardView.kt
@@ -1,4 +1,4 @@
-package fr.agrouagrou.mobileapp.ui.components
+package fr.agrouagrou.mobileapp.ui.gamephases
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
@@ -1,0 +1,23 @@
+package fr.agrouagrou.mobileapp.ui.gamephases
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.agrouagrou.grpc_server.R
+import fr.agrouagrou.mobileapp.ui.common.GameViewModel
+
+@Composable
+fun GamePhaseGameMasterRoute() {
+    Column(Modifier.padding(top = 48.dp, start = 16.dp)) {
+        Text(
+            text = stringResource(R.string.you_are_gamemaster),
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
@@ -4,7 +4,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -35,29 +40,40 @@ fun GamePhaseGameMasterRoute(gameViewModel: GameViewModel) {
         }
     }
 
-    Column(Modifier.padding(top = 48.dp)) {
-        Text(
-            text = stringResource(R.string.you_are_gamemaster),
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)
-        )
-        Text(
-            text = "${stringResource(R.string.game_status)} ${gameManager.gameState.value}",
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(start = 16.dp, bottom = 16.dp)
-        )
+    Scaffold(
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = {
+                    // will crash when werewolf/player's turn to vote
+                    gameManager.nextGameState()
+                },
+                icon = { Icon(Icons.Rounded.PlayArrow, "Next turn button") },
+                text = { Text(stringResource(R.string.next_turn)) }
+            )
+        }
+    ) { innerPadding ->
         Column(
             Modifier
-                .padding(start = 16.dp, bottom = 16.dp)
+                .padding(innerPadding)
                 .verticalScroll(rememberScrollState())
         ) {
-            Text(
-                text = stringResource(R.string.players_list),
-                style = MaterialTheme.typography.titleLarge
-            )
+            Column(Modifier.padding(start = 16.dp)) {
+                Text(
+                    text = stringResource(R.string.you_are_gamemaster),
+                    style = MaterialTheme.typography.headlineLarge,
                     color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+                Text(
                     text = "${stringResource(R.string.game_status)} ${stringResource(gameState.toLabel())}",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+                Text(
+                    text = stringResource(R.string.players_list),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
             PlayerList(players)
         }
     }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
@@ -2,22 +2,58 @@ package fr.agrouagrou.mobileapp.ui.gamephases
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.agrouagrou.grpc_server.R
 import fr.agrouagrou.mobileapp.ui.common.GameViewModel
+import fr.agrouagrou.mobileapp.ui.components.PlayerList
 
 @Composable
-fun GamePhaseGameMasterRoute() {
-    Column(Modifier.padding(top = 48.dp, start = 16.dp)) {
+fun GamePhaseGameMasterRoute(gameViewModel: GameViewModel) {
+    val gameManager by gameViewModel.gameManager.collectAsState()
+    var players by remember { mutableStateOf(gameManager.playerManager.players.values.toList()) }
+    var canStartGame by remember { mutableStateOf(gameManager.canStartGame()) }
+    LaunchedEffect(Unit) {
+        gameViewModel.watchForPlayerUpdates {
+            players = it
+            canStartGame = gameManager.canStartGame()
+        }
+    }
+
+    Column(Modifier.padding(top = 48.dp)) {
         Text(
             text = stringResource(R.string.you_are_gamemaster),
             style = MaterialTheme.typography.headlineLarge,
             color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)
         )
+        Text(
+            text = "${stringResource(R.string.game_status)} ${gameManager.gameState.value}",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(start = 16.dp, bottom = 16.dp)
+        )
+        Column(
+            Modifier
+                .padding(start = 16.dp, bottom = 16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = stringResource(R.string.players_list),
+                style = MaterialTheme.typography.titleLarge
+            )
+            PlayerList(players)
+        }
     }
 }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseGameMasterRoute.kt
@@ -18,11 +18,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.agrouagrou.grpc_server.R
 import fr.agrouagrou.mobileapp.ui.common.GameViewModel
+import fr.agrouagrou.mobileapp.ui.common.extensions.toLabel
 import fr.agrouagrou.mobileapp.ui.components.PlayerList
 
 @Composable
 fun GamePhaseGameMasterRoute(gameViewModel: GameViewModel) {
     val gameManager by gameViewModel.gameManager.collectAsState()
+    val gameState by gameManager.gameState.collectAsState()
+
     var players by remember { mutableStateOf(gameManager.playerManager.players.values.toList()) }
     var canStartGame by remember { mutableStateOf(gameManager.canStartGame()) }
     LaunchedEffect(Unit) {
@@ -53,6 +56,8 @@ fun GamePhaseGameMasterRoute(gameViewModel: GameViewModel) {
                 text = stringResource(R.string.players_list),
                 style = MaterialTheme.typography.titleLarge
             )
+                    color = MaterialTheme.colorScheme.primary,
+                    text = "${stringResource(R.string.game_status)} ${stringResource(gameState.toLabel())}",
             PlayerList(players)
         }
     }

--- a/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseRoute.kt
+++ b/app/src/main/java/fr/agrouagrou/mobileapp/ui/gamephases/GamePhaseRoute.kt
@@ -1,0 +1,14 @@
+package fr.agrouagrou.mobileapp.ui.gamephases
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun GamePhaseRoute() {}
+
+@Preview
+@Composable
+fun GamePhaseRoutePreview() {
+    GamePhaseRoute()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,11 @@
     <string name="you_are_gamemaster">You are the Game Master</string>
     <string name="game_status">Status:</string>
     <string name="players_list">Players:</string>
+    <string name="gamestate_looking_for_players">Looking for Players</string>
+    <string name="gamestate_night_start">Night start</string>
+    <string name="gamestate_night_fortune_teller">Fortune Teller\'s turn</string>
+    <string name="gamestate_night_werewolf">Werewolf\'s turn</string>
+    <string name="gamestate_night_witch">Witch\'s turn</string>
+    <string name="gamestate_day_debate">Day\'s debate</string>
+    <string name="gamestate_day_vote">Day\'s vote</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="your_game_id_is">Your game ID is: %1$s</string>
     <string name="waiting_for_players">Waiting for Players</string>
     <string name="join_game">Join Game</string>
+    <string name="start_game">Start Game</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="waiting_for_players">Waiting for Players</string>
     <string name="join_game">Join Game</string>
     <string name="start_game">Start Game</string>
+    <string name="you_are_gamemaster">You are the Game Master</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="join_game">Join Game</string>
     <string name="start_game">Start Game</string>
     <string name="you_are_gamemaster">You are the Game Master</string>
+    <string name="game_status">Status:</string>
+    <string name="players_list">Players:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="gamestate_night_witch">Witch\'s turn</string>
     <string name="gamestate_day_debate">Day\'s debate</string>
     <string name="gamestate_day_vote">Day\'s vote</string>
+    <string name="next_turn">Next turn</string>
 </resources>

--- a/common/src/main/kotlin/fr/agrouagrou/common/GameManager.kt
+++ b/common/src/main/kotlin/fr/agrouagrou/common/GameManager.kt
@@ -24,6 +24,9 @@ class GameManager(
         nextTurn()
     }
 
+    fun canStartGame(): Boolean =
+        gameState.value == GameState.LOOKING_FOR_PLAYERS && playerManager.players.size >= rules.minPlayers
+
     fun currentTurn(): GameTurn {
         val currentTurn = turns.lastOrNull() ?: throw IllegalStateException("Game has not started yet")
         return currentTurn


### PR DESCRIPTION
This adds the logic to show the game information for the Game Master, here, mainly when waiting for the players.

## Waiting for players

The button only show itself when there are enough players.

<img height="300" src="https://github.com/mmoreiradj/agrouagrou/assets/22498591/4074ed26-4174-4755-9538-74851c6ba9c0"/>

## Game Master In Game

I don't really know what to put here, so for now I only show the GameState and the players list.
With a floating button "Next turn", to move forward.

<img height="300" src="https://github.com/mmoreiradj/agrouagrou/assets/22498591/78a1488c-c8bc-4bce-9910-b902e7817b97"/>
